### PR TITLE
Fix for staking info

### DIFF
--- a/StratisCore.UI/src/app/wallet/dashboard/dashboard.component.ts
+++ b/StratisCore.UI/src/app/wallet/dashboard/dashboard.component.ts
@@ -169,10 +169,10 @@ export class DashboardComponent implements OnInit {
   private startStaking() {
     this.isStarting = true;
     this.isStopping = false;
-    let walletData = {
+    const walletData = {
       name: this.globalService.getWalletName(),
       password: this.stakingForm.get('walletPassword').value
-    }
+    };
     this.apiService.startStaking(walletData)
       .subscribe(
         response =>  {

--- a/StratisCore.UI/src/app/wallet/dashboard/dashboard.component.ts
+++ b/StratisCore.UI/src/app/wallet/dashboard/dashboard.component.ts
@@ -294,12 +294,14 @@ export class DashboardComponent implements OnInit {
   }
 
   private refreshStakingSubscription() {
+    if (this.sidechainEnabled) {
+      return;
+    }
+
     if (this.stakingInfoSubscription) {
       this.stakingInfoSubscription.unsubscribe();
     }
 
-    if (!this.sidechainEnabled) {
-      this.getStakingInfo();
-    }
+    this.getStakingInfo();
   }
 }

--- a/StratisCore.UI/src/app/wallet/dashboard/dashboard.component.ts
+++ b/StratisCore.UI/src/app/wallet/dashboard/dashboard.component.ts
@@ -178,6 +178,7 @@ export class DashboardComponent implements OnInit {
         response =>  {
           this.stakingEnabled = true;
           this.stakingForm.patchValue({ walletPassword: "" });
+          this.refreshStakingSubscription();
         },
         error => {
           this.isStarting = false;
@@ -287,6 +288,16 @@ export class DashboardComponent implements OnInit {
   private startSubscriptions() {
     this.getWalletBalance();
     this.getHistory();
+    if (!this.sidechainEnabled) {
+      this.getStakingInfo();
+    }
+  }
+
+  private refreshStakingSubscription() {
+    if (this.stakingInfoSubscription) {
+      this.stakingInfoSubscription.unsubscribe();
+    }
+
     if (!this.sidechainEnabled) {
       this.getStakingInfo();
     }


### PR DESCRIPTION
As far as I can see we only query staking details on init of the screen, so if staking hasn't started first load of the screen will not show you anything and starting staking will not get you the stats. Which explains why navigating away and back works as it would do a new query for the stats. We just need to explicitly call get staking info upon start of the staking.