### PR TITLE
Connect Core wallet to remote daemon

### DIFF
--- a/StratisCore.UI/main.ts
+++ b/StratisCore.UI/main.ts
@@ -27,6 +27,20 @@ if (testnet && !sidechain) {
   apiPort = 38225;
 }
 
+// Sets default arguments
+let daemonIP;
+let coreargs = require('minimist')(args, {
+  default : {
+    daemonip: 'localhost'
+  },
+});
+daemonIP = coreargs.daemonip;
+
+// Prevents daemon from starting if connecting to remote daemon.
+if (daemonIP != 'localhost') {
+  nodaemon = true;
+}
+
 ipcMain.on('get-port', (event, arg) => {
   event.returnValue = apiPort;
 });
@@ -37,6 +51,10 @@ ipcMain.on('get-testnet', (event, arg) => {
 
 ipcMain.on('get-sidechain', (event, arg) => {
   event.returnValue = sidechain;
+});
+
+ipcMain.on('get-daemonip', (event, arg) => {
+  event.returnValue = daemonIP;
 });
 
 require('electron-context-menu')({
@@ -145,7 +163,7 @@ function shutdownDaemon(portNumber) {
 
   var request = new http.ClientRequest({
     method: 'POST',
-    hostname: 'localhost',
+    hostname: daemonIP,
     port: portNumber,
     path: '/api/node/shutdown',
     headers: {

--- a/StratisCore.UI/package.json
+++ b/StratisCore.UI/package.json
@@ -55,6 +55,7 @@
   },
   "dependencies": {
     "electron-context-menu": "0.11.0",
+    "minimist": "^1.2.0",
     "ngx-pagination": "3.2.1",
     "ngx-qrcode2": "0.0.9"
   },
@@ -91,6 +92,7 @@
     "karma-coverage-istanbul-reporter": "2.0.5",
     "karma-jasmine": "2.0.1",
     "karma-jasmine-html-reporter": "1.4.0",
+    "minimist": "1.2.0",
     "ngx-bootstrap": "3.2.0",
     "ngx-clipboard": "12.0.0",
     "ngx-electron": "2.1.1",

--- a/StratisCore.UI/src/app/shared/services/api.service.ts
+++ b/StratisCore.UI/src/app/shared/services/api.service.ts
@@ -35,7 +35,7 @@ export class ApiService {
   setApiUrl() {
     this.apiPort = this.globalService.getApiPort();
     this.daemonIP = this.globalService.getDaemonIP();
-    this.stratisApiUrl = 'http://' + this.daemonIP + ":"+ this.apiPort + '/api';
+    this.stratisApiUrl = 'http://' + this.daemonIP + ':' + this.apiPort + '/api';
   }
 
   getNodeStatus(silent?: boolean): Observable<NodeStatus> {

--- a/StratisCore.UI/src/app/shared/services/api.service.ts
+++ b/StratisCore.UI/src/app/shared/services/api.service.ts
@@ -30,10 +30,12 @@ export class ApiService {
   private pollingInterval = interval(5000);
   private apiPort;
   private stratisApiUrl;
+  private daemonIP;
 
   setApiUrl() {
     this.apiPort = this.globalService.getApiPort();
-    this.stratisApiUrl = 'http://localhost:' + this.apiPort + '/api';
+    this.daemonIP = this.globalService.getDaemonIP();
+    this.stratisApiUrl = 'http://' + this.daemonIP + ":"+ this.apiPort + '/api';
   }
 
   getNodeStatus(silent?: boolean): Observable<NodeStatus> {

--- a/StratisCore.UI/src/app/shared/services/global.service.ts
+++ b/StratisCore.UI/src/app/shared/services/global.service.ts
@@ -10,6 +10,7 @@ export class GlobalService {
     this.setSidechainEnabled();
     this.setTestnetEnabled();
     this.setApiPort();
+    this.setDaemonIP();
   }
 
   private applicationVersion: string = "1.1.1";
@@ -24,6 +25,7 @@ export class GlobalService {
   private currentWalletName: string;
   private coinUnit: string;
   private network: string;
+  private daemonIP: string;
 
 
   getApplicationVersion() {
@@ -104,5 +106,17 @@ export class GlobalService {
 
   setCoinUnit(coinUnit: string) {
     this.coinUnit = coinUnit;
+  }
+
+  getDaemonIP() {
+    return this.daemonIP;
+  }
+
+  setDaemonIP() {
+    if (this.electronService.isElectronApp) {
+      this.daemonIP = this.electronService.ipcRenderer.sendSync('get-daemonip');
+    } else {
+      this.daemonIP = 'localhost';
+    }
   }
 }


### PR DESCRIPTION
This PR adds a command line option to connect to a remote Stratis Node daemon with the angular StratisCore wallet. This option can be used to remotely connect to a headless RPi setup by following MikeDennis's [instructions](https://medium.com/@mikedennis.blog/running-stratis-core-full-node-on-rpi3-5dd4f4073f92). 

-IP defaults to localhost if daemon IP is not provided. 
-If daemon IP is provided, local daemon is prevented from starting.

Usage:
`--daemonip=<ipaddress>`