### PR TITLE
Extend API service with message signing and verification

### DIFF
--- a/StratisCore.UI/src/app/shared/models/wallet-signmessagerequest.ts
+++ b/StratisCore.UI/src/app/shared/models/wallet-signmessagerequest.ts
@@ -1,0 +1,13 @@
+export class SignMessageRequest {
+  constructor(walletName: string, password: string, externalAddress: string, message: string) {
+    this.walletName = walletName;
+    this.password = password;
+    this.externalAddress = externalAddress;
+    this.message = message;
+  }
+
+  walletName: string;
+  password: string;
+  externalAddress: string;
+  message: string;
+}

--- a/StratisCore.UI/src/app/shared/models/wallet-verifyrequest.ts
+++ b/StratisCore.UI/src/app/shared/models/wallet-verifyrequest.ts
@@ -1,0 +1,11 @@
+export class VerifyRequest {
+  constructor(signature: string, externalAddress: string, message: string) {
+    this.signature = signature;
+    this.externalAddress = externalAddress;
+    this.message = message;
+  }
+
+  signature: string;
+  externalAddress: string;
+  message: string;
+}

--- a/StratisCore.UI/src/app/shared/services/api.service.ts
+++ b/StratisCore.UI/src/app/shared/services/api.service.ts
@@ -19,6 +19,7 @@ import { TransactionSending } from '../models/transaction-sending';
 import { NodeStatus } from '../models/node-status';
 import { WalletRescan } from '../models/wallet-rescan';
 import { SignMessageRequest } from '../models/wallet-signmessagerequest';
+import { VerifyRequest } from '../models/wallet-verifyrequest';
 
 @Injectable({
   providedIn: 'root'
@@ -327,6 +328,15 @@ export class ApiService {
  */
   signMessage(data: SignMessageRequest): Observable<any> {
     return this.http.post(this.stratisApiUrl + '/wallet/signmessage',  JSON.stringify(data)).pipe(
+      catchError(err => this.handleHttpError(err))
+    );
+  }
+
+  /**
+ * Verify the given signature with the private key of the given address
+ */
+  verify(data: VerifyRequest): Observable<any> {
+    return this.http.post(this.stratisApiUrl + '/wallet/verify',  JSON.stringify(data)).pipe(
       catchError(err => this.handleHttpError(err))
     );
   }

--- a/StratisCore.UI/src/app/shared/services/api.service.ts
+++ b/StratisCore.UI/src/app/shared/services/api.service.ts
@@ -333,7 +333,7 @@ export class ApiService {
   }
 
   /**
- * Verify the given signature with the private key of the given address
+ * Verify the given signature with the given address
  */
   verify(data: VerifyRequest): Observable<any> {
     return this.http.post(this.stratisApiUrl + '/wallet/verify',  JSON.stringify(data)).pipe(

--- a/StratisCore.UI/src/app/shared/services/api.service.ts
+++ b/StratisCore.UI/src/app/shared/services/api.service.ts
@@ -18,6 +18,7 @@ import { TransactionBuilding } from '../models/transaction-building';
 import { TransactionSending } from '../models/transaction-sending';
 import { NodeStatus } from '../models/node-status';
 import { WalletRescan } from '../models/wallet-rescan';
+import { SignMessageRequest } from '../models/wallet-signmessagerequest';
 
 @Injectable({
   providedIn: 'root'
@@ -317,6 +318,15 @@ export class ApiService {
       .set('fromDate', data.fromDate.toDateString())
       .set('reSync', 'true');
     return this.http.delete(this.stratisApiUrl + '/wallet/remove-transactions/', { params }).pipe(
+      catchError(err => this.handleHttpError(err))
+    );
+  }
+
+  /**
+ * Sign the given message with the private key of the given address
+ */
+  signMessage(data: SignMessageRequest): Observable<any> {
+    return this.http.post(this.stratisApiUrl + '/wallet/signmessage',  JSON.stringify(data)).pipe(
       catchError(err => this.handleHttpError(err))
     );
   }


### PR DESCRIPTION
We have extended the API service with a method to sign and verify messages and we have added the appropriate models for it.