### PR TITLE
Removed unused buttons and styles

### DIFF
--- a/StratisCore.UI/src/app/wallet/smart-contracts/components/modals/transaction/transaction.component.css
+++ b/StratisCore.UI/src/app/wallet/smart-contracts/components/modals/transaction/transaction.component.css
@@ -1,0 +1,3 @@
+.no-underline {
+    text-decoration: none;
+}

--- a/StratisCore.UI/src/app/wallet/smart-contracts/components/modals/transaction/transaction.component.html
+++ b/StratisCore.UI/src/app/wallet/smart-contracts/components/modals/transaction/transaction.component.html
@@ -111,7 +111,7 @@
                     <div *ngIf="mode === modeEnum.Create">
                         <div class="form-group clearfix" data-toggle="tooltip" data-placement="right" title="The bytecode of the contract to deploy">
                             <label class="float-left" for="contractCode">Byte Code</label>
-                            <textarea class="form-control form-control-sm" id="contractCode" rows="5" formControlName="contractCode" #byteCodeElement
+                            <textarea class="form-control form-control-sm" id="contractCode" rows="5" formControlName="contractCode"
                                 [class.is-invalid]="contractCode.invalid && (contractCode.dirty || contractCode.touched)">{{contractCode}}</textarea>
                             <div *ngIf="contractCode.errors" class="invalid-feedback">
                                 <p *ngIf="contractCode.errors.hasOddNumberOfCharacters">Must have an even number of characters</p>

--- a/StratisCore.UI/src/app/wallet/smart-contracts/components/modals/transaction/transaction.component.html
+++ b/StratisCore.UI/src/app/wallet/smart-contracts/components/modals/transaction/transaction.component.html
@@ -13,7 +13,7 @@
                     <input class="form-control" [(ngModel)]="selectedSenderAddress" [ngModelOptions]="{standalone: true}" [readonly]="true" />
                 </div>
                 <div class="float-right">Balance : <sc-balance data-toggle="tooltip" data-placement="top" title=""
-                        data-original-title="Set maximum amount" class="btn-link" [balance]="balance" [coinUnit]="coinUnit"></sc-balance>
+                        data-original-title="Set maximum amount" class="btn-link no-underline" [balance]="balance" [coinUnit]="coinUnit"></sc-balance>
                 </div>
                 <div class="form-group clearfix" data-toggle="tooltip" data-placement="right" title="The amount of {{ coinUnit }} to send with this transaction">
                     <label for="amount">Amount</label>
@@ -111,11 +111,7 @@
                     <div *ngIf="mode === modeEnum.Create">
                         <div class="form-group clearfix" data-toggle="tooltip" data-placement="right" title="The bytecode of the contract to deploy">
                             <label class="float-left" for="contractCode">Byte Code</label>
-                            <span class="float-right">
-                                <button type="button" class="btn btn-link d-inline-block ml-2 btn-sm" data-toggle="tooltip"
-                                    data-placement="right" title="" data-original-title="Copy to Clipboard">Copy</button>
-                            </span>
-                            <textarea class="form-control form-control-sm" id="contractCode" rows="5" formControlName="contractCode"
+                            <textarea class="form-control form-control-sm" id="contractCode" rows="5" formControlName="contractCode" #byteCodeElement
                                 [class.is-invalid]="contractCode.invalid && (contractCode.dirty || contractCode.touched)">{{contractCode}}</textarea>
                             <div *ngIf="contractCode.errors" class="invalid-feedback">
                                 <p *ngIf="contractCode.errors.hasOddNumberOfCharacters">Must have an even number of characters</p>

--- a/StratisCore.UI/src/app/wallet/smart-contracts/components/smart-contracts.component.html
+++ b/StratisCore.UI/src/app/wallet/smart-contracts/components/smart-contracts.component.html
@@ -79,9 +79,7 @@
                                 </td>
                                 <td><code class="d-inline-block">{{item.to}}</code></td>
                                 <td><sc-balance [balance]="item.amount" [coinUnit]="coinUnit"></sc-balance></td>
-                                <td><button data-toggle="modal" data-target="#modalInfotx" data-toggle="tooltip"
-                                        data-placement="top" title="" data-original-title="See details" class="btn btn-primary btn-sm"
-                                        type="button">+</button></td>
+                                <td>&nbsp;</td>
                             </tr>
 
                         </tbody>


### PR DESCRIPTION
A small changes to remove unused "copy" button, "plus" button and removed underline from balance so that it doesn't look like it is something that can be clicked/tapped