### PR TITLE
Confirm Passphrase

### DIFF
--- a/StratisCore.UI/src/app/setup/create/create.component.css
+++ b/StratisCore.UI/src/app/setup/create/create.component.css
@@ -1,0 +1,8 @@
+/* Allows for vertical scrolling if form gets too long. */
+.createWallet {
+  overflow-y: scroll;
+  max-height: 100vh;
+  display: block !important;
+  padding-top: 25px;
+  padding-bottom: 25px;
+}

--- a/StratisCore.UI/src/app/setup/create/create.component.css
+++ b/StratisCore.UI/src/app/setup/create/create.component.css
@@ -1,8 +1,0 @@
-/* Allows for vertical scrolling if form gets too long. */
-.createWallet {
-  overflow-y: scroll;
-  max-height: 100vh;
-  display: block !important;
-  padding-top: 25px;
-  padding-bottom: 25px;
-}

--- a/StratisCore.UI/src/app/setup/create/create.component.html
+++ b/StratisCore.UI/src/app/setup/create/create.component.html
@@ -30,9 +30,13 @@
         <!-- /form-group -->
         <div class="form-group col-12">
           <label for="walletPassphrase mr-auto">Passphrase</label><em class="text-muted ml-auto float-right">(optional)</em>
-          <!--[class.is-invalid]="formErrors.walletPassphrase" [class.is-valid]="!formErrors.walletPassphrase && createWalletForm.get('walletPassphrase').valid"-->
-          <input type="password" class="form-control form-control-success" formControlName="walletPassphrase" id="walletPassphrase" placeholder="Enter an optional passphrase." placement="right" ngbTooltip="The passphrase will be combined with your secret words to generate the private seed and will be required to restore your wallet in the future if necessary." triggers="click:blur">
+          <input type="password" class="form-control" [class.is-invalid]="formErrors.walletPassphrase" [class.is-valid]="!formErrors.walletPassphrase && createWalletForm.get('walletPassphrase').valid && createWalletForm.get('walletPassphrase').dirty" formControlName="walletPassphrase" id="walletPassphrase" placeholder="Enter an optional passphrase." placement="right" ngbTooltip="The passphrase will be combined with your secret words to generate the private seed and will be required to restore your wallet in the future if necessary." triggers="click:blur">
           <div *ngIf="formErrors.walletPassphrase" class="invalid-feedback">{{ formErrors.walletPassphrase }}</div>
+        </div>
+        <div class="form-group col-12" *ngIf="createWalletForm.get('walletPassphrase').dirty">
+          <label for="walletPassphrase mr-auto">Confirm Passphrase</label>
+          <input type="password" class="form-control" [class.is-invalid]="formErrors.walletPassphraseConfirmation" [class.is-valid]="!formErrors.walletPassphraseConfirmation && createWalletForm.get('walletPassphrase').valid && createWalletForm.get('walletPassphraseConfirmation').dirty && createWalletForm.get('walletPassphraseConfirmation').valid" formControlName="walletPassphraseConfirmation" id="walletPassphraseConfirmation" placeholder="Confirm passphrase." triggers="click:blur">
+          <div *ngIf="formErrors.walletPassphraseConfirmation" class="invalid-feedback">{{ formErrors.walletPassphraseConfirmation }}</div>
         </div>
         <div class="col-12">
           <div class="alert alert-danger text-center" role="alert">

--- a/StratisCore.UI/src/app/setup/create/create.component.ts
+++ b/StratisCore.UI/src/app/setup/create/create.component.ts
@@ -33,7 +33,7 @@ export class CreateComponent implements OnInit {
 
   private buildCreateForm(): void {
     this.createWalletForm = this.fb.group({
-      "walletName": ["",
+      walletName: ['',
         Validators.compose([
           Validators.required,
           Validators.minLength(1),
@@ -41,15 +41,15 @@ export class CreateComponent implements OnInit {
           Validators.pattern(/^[a-zA-Z0-9]*$/)
         ])
       ],
-      "walletPassphrase" : [""],
-      "walletPassword": ["",
+      walletPassphrase : [''],
+      walletPassword: ['',
         Validators.required,
         // Validators.compose([
         //   Validators.required,
         //   Validators.pattern(/^(?=.*[a-z])(?=.*[A-Z])(?=.*[0-9])(?=.{10,})/)])
         ],
-      "walletPasswordConfirmation": ["", Validators.required],
-      "selectNetwork": ["test", Validators.required]
+      walletPasswordConfirmation: ['', Validators.required],
+      selectNetwork: ["test", Validators.required]
     }, {
       validator: PasswordValidationDirective.MatchPassword
     });
@@ -76,26 +76,26 @@ export class CreateComponent implements OnInit {
   }
 
   formErrors = {
-    'walletName': '',
-    'walletPassphrase': '',
-    'walletPassword': '',
-    'walletPasswordConfirmation': ''
+    walletName: '',
+    walletPassphrase: '',
+    walletPassword: '',
+    walletPasswordConfirmation: ''
   };
 
   validationMessages = {
-    'walletName': {
-      'required': 'A wallet name is required.',
-      'minlength': 'A wallet name must be at least one character long.',
-      'maxlength': 'A wallet name cannot be more than 24 characters long.',
-      'pattern': 'Please enter a valid wallet name. [a-Z] and [0-9] are the only characters allowed.'
+    walletName: {
+      required: 'A wallet name is required.',
+      minlength: 'A wallet name must be at least one character long.',
+      maxlength: 'A wallet name cannot be more than 24 characters long.',
+      pattern: 'Please enter a valid wallet name. [a-Z] and [0-9] are the only characters allowed.'
     },
-    'walletPassword': {
-      'required': 'A password is required.',
-      'pattern': 'A password must be at least 10 characters long and contain one lowercase and uppercase alphabetical character and a number.'
+    walletPassword: {
+      required: 'A password is required.',
+      pattern: 'A password must be at least 10 characters long and contain one lowercase and uppercase alphabetical character and a number.'
     },
-    'walletPasswordConfirmation': {
-      'required': 'Confirm your password.',
-      'walletPasswordConfirmation': 'Passwords do not match.'
+    walletPasswordConfirmation: {
+      required: 'Confirm your password.',
+      walletPasswordConfirmation: 'Passwords do not match.'
     }
   };
 

--- a/StratisCore.UI/src/app/shared/directives/password-validation.directive.ts
+++ b/StratisCore.UI/src/app/shared/directives/password-validation.directive.ts
@@ -18,4 +18,16 @@ export class PasswordValidationDirective {
       return null;
     }
   }
+
+  static MatchPassphrase(AC: AbstractControl) {
+    let passphrase = AC.get('walletPassphrase').value;
+    let confirmPassphrase = AC.get('walletPassphraseConfirmation').value;
+
+    if(passphrase !== confirmPassphrase) {
+      AC.get('walletPassphraseConfirmation').setErrors({ walletPassphraseConfirmation: true });
+    } else {
+      AC.get('walletPassphraseConfirmation').setErrors(null);
+      return null;
+    }
+  }
 }

--- a/StratisCore.UI/src/scss/_custom.scss
+++ b/StratisCore.UI/src/scss/_custom.scss
@@ -779,6 +779,13 @@ img {pointer-events: none !important;}
 
 // Wallet creation
 .createWallet {
+  /* Allows for vertical scrolling if form gets too long. */
+  overflow-y: scroll;
+  max-height: 100vh;
+  display: block !important;
+  padding-top: 25px;
+  padding-bottom: 25px;
+
   .bs-tooltip-right {
     width: 260px;
   }


### PR DESCRIPTION
Confirm passphrase when creating a wallet. 

* Add MatchPassphrase validator
* Clear passphrase validators when required
* Clean up and unsub all subscriptions
* Using `'` consistently over `"`
* Allow vertical scrolling on create wallet form if it gets too tall