### PR TITLE
Remove wallet files for DB based Wallets

### DIFF
--- a/StratisCore.UI/src/app/shared/services/api.service.ts
+++ b/StratisCore.UI/src/app/shared/services/api.service.ts
@@ -6,7 +6,6 @@ import { GlobalService } from './global.service';
 import { AddressLabel } from '../models/address-label';
 import { WalletCreation } from '../models/wallet-creation';
 import { WalletRecovery } from '../models/wallet-recovery';
-import { WalletLoad } from '../models/wallet-load';
 import { WalletInfo, WalletInfoRequest } from '../models/wallet-info';
 import { NodeStatus } from '../models/node-status';
 import { WalletRescan } from '../models/wallet-rescan';
@@ -14,7 +13,7 @@ import { LocalExecutionResult } from '@shared/models/local-execution-result';
 import { TokenBalanceRequest } from 'src/app/wallet/tokens/models/token-balance-request';
 import { RestApi } from '@shared/services/rest-api';
 import { IApiService } from '@shared/services/interfaces/services.i';
-import { WalletFileData, WalletHistory } from '@shared/services/interfaces/api.i';
+import {  WalletHistory } from '@shared/services/interfaces/api.i';
 import { ErrorService } from '@shared/services/error-service';
 
 @Injectable({
@@ -61,14 +60,6 @@ export class ApiService extends RestApi implements IApiService {
     );
   }
 
-  /**
-   * Gets available wallets at the default path
-   */
-  public getWalletFiles(): Observable<WalletFileData> {
-    return this.get<WalletFileData>('wallet/files').pipe(
-      catchError(err => this.handleHttpError(err))
-    );
-  }
 
   /** Gets the extended public key from a certain wallet */
   public getExtPubkey(data: WalletInfo): Observable<any> {
@@ -104,15 +95,6 @@ export class ApiService extends RestApi implements IApiService {
    */
   public recoverStratisWallet(data: WalletRecovery): Observable<any> {
     return this.post('wallet/recover/', data).pipe(
-      catchError(err => this.handleHttpError(err))
-    );
-  }
-
-  /**
-   * Load a Stratis wallet
-   */
-  public loadStratisWallet(data: WalletLoad): Observable<any> {
-    return this.post('wallet/load/', data).pipe(
       catchError(err => this.handleHttpError(err))
     );
   }

--- a/StratisCore.UI/src/app/shared/services/interfaces/api.i.ts
+++ b/StratisCore.UI/src/app/shared/services/interfaces/api.i.ts
@@ -1,6 +1,5 @@
-export interface WalletFileData {
-  walletsPath: string;
-  walletsFiles: [string];
+export interface WalletNamesData {
+  walletNames: Array<string>;
 }
 
 export interface Money {

--- a/StratisCore.UI/src/app/shared/services/interfaces/services.i.ts
+++ b/StratisCore.UI/src/app/shared/services/interfaces/services.i.ts
@@ -29,11 +29,6 @@ export interface IApiService {
 
   removeAddressBookAddress(label: string): Observable<any>;
 
-  /**
-   * Gets available wallets at the default path
-   */
-  getWalletFiles(): Observable<any>;
-
   /** Gets the extended public key from a certain wallet */
   getExtPubkey(data: WalletInfo): Observable<any>;
 
@@ -51,11 +46,6 @@ export interface IApiService {
    * Recover a Stratis wallet.
    */
   recoverStratisWallet(data: WalletRecovery): Observable<any>;
-
-  /**
-   * Load a Stratis wallet
-   */
-  loadStratisWallet(data: WalletLoad): Observable<any>;
 
   /**
    * Get wallet status info from the API.

--- a/StratisCore.UI/src/app/wallet/staking/staking.component.html
+++ b/StratisCore.UI/src/app/wallet/staking/staking.component.html
@@ -31,7 +31,7 @@
           <li *ngIf="stakingService.isStarting">Waiting for staking to start...</li>
           <ng-container *ngIf="!stakingService.isStarting && (stakingInfo | async) as _stakingInfo">
             <li>Staking weight:
-              <strong>{{ _stakingInfo.netStakeWeight | coinNotation | number: '1.0-0' }} {{ globalService.coinUnit }}</strong>
+              <strong>{{ _stakingInfo.weight | coinNotation | number: '1.0-0' }} {{ globalService.coinUnit }}</strong>
             </li>
             <li>Coins awaiting maturity:
               <strong>{{ _wallet.awaitingMaturityIfStaking | coinNotation | number: '1.0-0' }} {{ globalService.coinUnit }}</strong>


### PR DESCRIPTION
This PR removes the endpoint calls for Wallet files and now uses the `list-wallets` endpoint.