### PR TITLE
Use wallet-sync instead of remove-transactions for Wallet Resync

### DIFF
--- a/StratisCore.UI/src/app/shared/models/wallet-rescan.ts
+++ b/StratisCore.UI/src/app/shared/models/wallet-rescan.ts
@@ -1,13 +1,11 @@
-export class WalletRescan {
-  constructor(walletName: string, fromDate: Date, all: boolean, resync: boolean) {
-    this.name = walletName;
-    this.fromDate = fromDate;
+export class WalletResync {
+  constructor(walletName: string, date: Date, all: boolean) {
+    this.walletName = walletName;
+    this.date = date;
     this.all = all;
-    this.resync = resync;
   }
 
-  name: string;
-  fromDate: Date;
+  walletName: string;
+  date: Date;
   all: boolean;
-  resync: boolean;
 }

--- a/StratisCore.UI/src/app/shared/services/api.service.ts
+++ b/StratisCore.UI/src/app/shared/services/api.service.ts
@@ -8,12 +8,11 @@ import { WalletCreation } from '../models/wallet-creation';
 import { WalletRecovery } from '../models/wallet-recovery';
 import { WalletInfo, WalletInfoRequest } from '../models/wallet-info';
 import { NodeStatus } from '../models/node-status';
-import { WalletRescan } from '../models/wallet-rescan';
 import { LocalExecutionResult } from '@shared/models/local-execution-result';
 import { TokenBalanceRequest } from 'src/app/wallet/tokens/models/token-balance-request';
 import { RestApi } from '@shared/services/rest-api';
 import { IApiService } from '@shared/services/interfaces/services.i';
-import {  WalletHistory } from '@shared/services/interfaces/api.i';
+import { WalletHistory } from '@shared/services/interfaces/api.i';
 import { ErrorService } from '@shared/services/error-service';
 
 @Injectable({
@@ -150,18 +149,6 @@ export class ApiService extends RestApi implements IApiService {
       catchError(err => this.handleHttpError(err))
     );
   }
-
-  /** Rescan wallet from a certain date using remove-transactions */
-  public rescanWallet(data: WalletRescan): Observable<any> {
-    const params = new HttpParams()
-      .set('walletName', data.name)
-      .set('fromDate', data.fromDate.toDateString())
-      .set('reSync', 'true');
-    return this.delete('wallet/remove-transactions/', params).pipe(
-      catchError(err => this.handleHttpError(err))
-    );
-  }
-
 
   /**
    * Send shutdown signal to the daemon

--- a/StratisCore.UI/src/app/shared/services/interfaces/services.i.ts
+++ b/StratisCore.UI/src/app/shared/services/interfaces/services.i.ts
@@ -4,12 +4,6 @@ import { AddressLabel } from '@shared/models/address-label';
 import { WalletInfo } from '@shared/models/wallet-info';
 import { WalletCreation } from '@shared/models/wallet-creation';
 import { WalletRecovery } from '@shared/models/wallet-recovery';
-import { WalletLoad } from '@shared/models/wallet-load';
-import { FeeEstimation } from '@shared/models/fee-estimation';
-import { SidechainFeeEstimation } from '@shared/models/sidechain-fee-estimation';
-import { Transaction } from '@shared/models/transaction';
-import { TransactionSending } from '@shared/models/transaction-sending';
-import { WalletRescan } from '@shared/models/wallet-rescan';
 import { LocalExecutionResult } from '@shared/models/local-execution-result';
 import { TokenBalanceRequest } from '../../../wallet/tokens/models/token-balance-request';
 
@@ -69,9 +63,6 @@ export interface IApiService {
 
   /** Remove transaction */
   removeTransaction(walletName: string): Observable<any>;
-
-  /** Rescan wallet from a certain date using remove-transactions */
-  rescanWallet(data: WalletRescan): Observable<any>;
 
   /**
    * Send shutdown signal to the daemon

--- a/StratisCore.UI/src/app/shared/services/wallet.service.ts
+++ b/StratisCore.UI/src/app/shared/services/wallet.service.ts
@@ -25,6 +25,7 @@ import { BuildTransactionResponse, TransactionResponse } from '@shared/models/tr
 import { FeeEstimation } from '@shared/models/fee-estimation';
 import { CurrentAccountService } from '@shared/services/current-account.service';
 import { WalletLoad } from '@shared/models/wallet-load';
+import { WalletResync } from '@shared/models/wallet-rescan';
 
 @Injectable({
   providedIn: 'root'
@@ -100,7 +101,6 @@ export class WalletService extends RestApi {
     );
   }
 
-
   public transactionReceived(): Observable<any> {
     return this.transactionReceivedSubject.asObservable();
   }
@@ -113,6 +113,15 @@ export class WalletService extends RestApi {
 
   public getUnusedReceiveAddress(data: WalletInfo): Observable<any> {
     return this.get('wallet/unusedaddress', this.getWalletParams(data)).pipe(
+      catchError(err => this.handleHttpError(err))
+    );
+  }
+
+  public rescanWallet(data: WalletResync): Observable<any> {
+    return this.post('wallet/sync-from-date/', data).pipe(
+      tap(() => {
+        this.refreshWalletHistory();
+      }),
       catchError(err => this.handleHttpError(err))
     );
   }

--- a/StratisCore.UI/src/app/shared/services/wallet.service.ts
+++ b/StratisCore.UI/src/app/shared/services/wallet.service.ts
@@ -65,7 +65,14 @@ export class WalletService extends RestApi {
 
     signalRService.registerOnMessageEventHandler<WalletInfoSignalREvent>(SignalREvents.WalletGeneralInfo,
       (message) => {
+
+        // Get History once chain is synced
+        if (this.ibdMode && message.isChainSynced) {
+          this.refreshWalletHistory();
+        }
+
         this.ibdMode = !message.isChainSynced;
+
         if (this.currentWallet && message.walletName === this.currentWallet.walletName) {
           const walletBalance = message.accountsBalances.find(acc => acc.accountName === `account ${this.currentWallet.account}`);
           this.updateWalletForCurrentAddress(walletBalance);

--- a/StratisCore.UI/src/app/wallet/advanced/components/resync/resync.component.ts
+++ b/StratisCore.UI/src/app/wallet/advanced/components/resync/resync.component.ts
@@ -7,8 +7,9 @@ import { Subscription } from 'rxjs';
 import { ApiService } from '@shared/services/api.service';
 import { GlobalService } from '@shared/services/global.service';
 import { ModalService } from '@shared/services/modal.service';
-import { WalletRescan } from '@shared/models/wallet-rescan';
 import { NodeService } from '@shared/services/node-service';
+import { WalletService } from '@shared/services/wallet.service';
+import { WalletResync } from "@shared/models/wallet-rescan";
 
 @Component({
   selector: 'app-resync',
@@ -20,11 +21,11 @@ export class ResyncComponent implements OnInit, OnDestroy {
   constructor(
     private globalService: GlobalService,
     private apiService: ApiService,
+    private walletService: WalletService,
     private nodeService: NodeService,
     private genericModalService: ModalService,
     private fb: FormBuilder) {
   }
-
 
 
   private walletName: string;
@@ -71,7 +72,9 @@ export class ResyncComponent implements OnInit, OnDestroy {
   }
 
   onValueChanged(data?: any) {
-    if (!this.rescanWalletForm) { return; }
+    if (!this.rescanWalletForm) {
+      return;
+    }
     const form = this.rescanWalletForm;
     for (const field in this.formErrors) {
       this.formErrors[field] = '';
@@ -89,14 +92,13 @@ export class ResyncComponent implements OnInit, OnDestroy {
     const rescanDate = new Date(this.rescanWalletForm.get('walletDate').value);
     rescanDate.setDate(rescanDate.getDate() - 1);
 
-    const rescanData = new WalletRescan(
+    const rescanData = new WalletResync(
       this.walletName,
       rescanDate,
-      false,
-      true
+      false
     );
 
-    this.apiService
+    this.walletService
       .rescanWallet(rescanData)
       .subscribe(
         response => {
@@ -108,7 +110,7 @@ export class ResyncComponent implements OnInit, OnDestroy {
   private getGeneralWalletInfo() {
     this.generalWalletInfoSubscription = this.nodeService.generalInfo()
       .subscribe(
-        response =>  {
+        response => {
           const generalWalletInfoResponse = response;
           this.lastBlockSyncedHeight = generalWalletInfoResponse.lastBlockSyncedHeight;
           this.chainTip = generalWalletInfoResponse.chainTip;
@@ -126,11 +128,13 @@ export class ResyncComponent implements OnInit, OnDestroy {
       )
     ;
   }
+
   private cancelSubscriptions() {
     if (this.generalWalletInfoSubscription) {
       this.generalWalletInfoSubscription.unsubscribe();
     }
   }
+
   private startSubscriptions() {
     this.getGeneralWalletInfo();
   }


### PR DESCRIPTION
This PR updates core UI to use `wallet-sync` endpoint instead of `remove-transactions` for Wallet Re-sync Operations.

This is because remove-transactions is no longer supported on the new SQL Wallet.