### PR TITLE
Fix UI Responsiveness around Transaction History

### DIFF
--- a/StratisCore.UI/src/app/shared/services/wallet.service.ts
+++ b/StratisCore.UI/src/app/shared/services/wallet.service.ts
@@ -53,9 +53,11 @@ export class WalletService extends RestApi {
       this.currentWallet = wallet;
     });
 
-    currentAccountService.currentAddress.subscribe(() => {
+    currentAccountService.currentAddress.subscribe((address) => {
       this.accountsEnabled = globalService.getSidechainEnabled() && this.currentAccountService.hasActiveAddress();
-      this.updateWalletForCurrentAddress();
+      if (null != address) {
+        this.updateWalletForCurrentAddress();
+      }
     });
 
     // When we get a TransactionReceived event get the WalletBalance and History using the RestApi
@@ -283,6 +285,7 @@ export class WalletService extends RestApi {
     if (this.accountsEnabled) {
       if (null == newBalance.currentAddress || newBalance.currentAddress.address !== this.currentAccountService.address) {
         newBalance.setCurrentAccountAddress(this.currentAccountService.address);
+        this.clearWalletHistory(0);
         this.refreshWalletHistory();
       }
     }
@@ -304,7 +307,9 @@ export class WalletService extends RestApi {
   }
 
   private clearWalletHistory(fromDate: number): void {
-    const walletHistorySubject = this.getWalletHistorySubject(this.currentWallet);
-    walletHistorySubject.next(Array.from(walletHistorySubject.value.filter(item => item.timestamp < fromDate)));
+    if (this.currentWallet) {
+      const walletHistorySubject = this.getWalletHistorySubject(this.currentWallet);
+      walletHistorySubject.next(Array.from((walletHistorySubject.value || []).filter(item => item.timestamp < fromDate)));
+    }
   }
 }

--- a/StratisCore.UI/src/app/wallet/status-bar/status-bar.component.ts
+++ b/StratisCore.UI/src/app/wallet/status-bar/status-bar.component.ts
@@ -27,7 +27,8 @@ export class StatusBarComponent implements OnInit {
     this.generalInfo = this.nodeService.generalInfo()
       .pipe(tap(
         response => {
-          let percentSyncedNumber = ((response.lastBlockSyncedHeight / response.chainTip) * 100);
+          // If ChainTip is behind wallet stop sync percent being greater than 100%.
+          let percentSyncedNumber = Math.min((response.lastBlockSyncedHeight / response.chainTip) * 100, 100);
           if (percentSyncedNumber.toFixed(0) === '100' && response.lastBlockSyncedHeight !== response.chainTip) {
             percentSyncedNumber = 99;
           }


### PR DESCRIPTION
This PR fixes responsiveness around the transaction history especially on Cirrus Core when changing addresses. Also stop sync going above 100% this can happen if the chain tip is behind the wallet which can happen in some circumstances.