### PR TITLE
Order address by balance + minor null check guards

### DIFF
--- a/StratisCore.UI/src/app/shared/models/address-balance.ts
+++ b/StratisCore.UI/src/app/shared/models/address-balance.ts
@@ -1,0 +1,11 @@
+export interface Address {
+  address: string;
+  isUsed: boolean;
+  isChange: boolean;
+  amountConfirmed: number;
+  amountUnconfirmed: number;
+}
+
+export interface AddressBalance {
+  addresses: Address[];
+}

--- a/StratisCore.UI/src/app/wallet/dashboard/dashboard.component.html
+++ b/StratisCore.UI/src/app/wallet/dashboard/dashboard.component.html
@@ -47,7 +47,7 @@
                           [maxTransactionCount]="5" [enableShowHistoryButton]="true">
         </app-transactions>
       </div>
-      <div class="col-4" *ngIf="!globalService.getSidechainEnabled() && !walletService.ibdMode && !walletService.isSyncing">
+      <div class="col-4" *ngIf="!globalService.getSidechainEnabled() && !walletService.ibdMode">
         <app-staking></app-staking>
       </div>
 

--- a/StratisCore.UI/src/app/wallet/smart-contracts/components/address-selection/address-selection.component.ts
+++ b/StratisCore.UI/src/app/wallet/smart-contracts/components/address-selection/address-selection.component.ts
@@ -8,6 +8,7 @@ import { Router } from '@angular/router';
 import { WalletInfo } from '@shared/models/wallet-info';
 import { WalletService } from '@shared/services/wallet.service';
 import { Log } from '../../../tokens/services/logger.service';
+import { AddressBalance } from '@shared/models/address-balance';
 
 @Component({
   selector: 'app-address-selection',
@@ -38,14 +39,15 @@ export class AddressSelectionComponent implements OnInit, OnDestroy {
       .pipe(
         catchError(error => {
           Log.error(error);
-          return of([]);
+          return of(<AddressBalance>{addresses: []});
         }),
         takeUntil(this.unsubscribe))
-      .subscribe(addresses => {
-        if (addresses && addresses.hasOwnProperty('addresses')) {
-          if (addresses.addresses.length > 0) {
-            this.addressChangedSubject.next(addresses.addresses[0].address);
-            this.addresses = addresses.addresses.filter(a => a.isChange === false || (a.amountConfirmed > 0 || a.amountUnconfirmed > 0));
+      .subscribe(addressBalance => {
+        if (addressBalance && addressBalance.hasOwnProperty('addresses')) {
+          if (addressBalance.addresses.length > 0) {
+            this.addressChangedSubject.next(addressBalance.addresses[0].address);
+            this.addresses = addressBalance.addresses
+              .filter(a => a.isChange === false || (a.amountConfirmed > 0 || a.amountUnconfirmed > 0));
             this.selectedAddress = this.addresses[0].address;
           }
         }


### PR DESCRIPTION
This PR fixes the following

- CirrusCore Address's are now ordered by Balance

- Fixes a number of console errors in Cirrus when no address is selected

- Revert hide staking box when Syncing. IBD Check still exists.

- Only get history when Balance Changes, no longer use `BlockConnectedEvent`