### PR TITLE
Check that Wallet Feature is enabled on startup

### DIFF
--- a/StratisCore.UI/src/app/app.component.ts
+++ b/StratisCore.UI/src/app/app.component.ts
@@ -18,7 +18,8 @@ import { NodeStatus } from '@shared/models/node-status';
 })
 
 export class AppComponent implements OnInit, OnDestroy {
-  constructor(private router: Router, private apiService: ApiService, private globalService: GlobalService, private titleService: Title, private electronService: ElectronService) { }
+  constructor(private router: Router, private apiService: ApiService, private globalService: GlobalService, private titleService: Title, private electronService: ElectronService) {
+  }
 
   private subscription: Subscription;
   private statusIntervalSubscription: Subscription;
@@ -62,9 +63,11 @@ export class AppComponent implements OnInit, OnDestroy {
         this.apiConnected = true;
         this.statusIntervalSubscription = this.apiService.getNodeStatusInterval(true)
           .subscribe(
-            response =>  {
+            response => {
               const statusResponse = response.featuresData.filter(x => x.namespace === 'Stratis.Bitcoin.Base.BaseFeature');
-              if (statusResponse.length > 0 && statusResponse[0].state === 'Initialized') {
+              const walletFeatureResponse = response.featuresData.find(x => x.namespace === 'Stratis.Bitcoin.Features.Wallet.WalletFeature');
+              if (statusResponse.length > 0 && statusResponse[0].state === 'Initialized'
+                && walletFeatureResponse && walletFeatureResponse.state === 'Initialized') {
                 this.loading = false;
                 this.statusIntervalSubscription.unsubscribe();
                 this.router.navigate(['login']);


### PR DESCRIPTION
This PR Checks the `Stratis.Bitcoin.Features.Wallet.WalletFeature.State` object on startup before showing the list of Wallets. 

Needed when performance of Importing JSON Wallets for the first time is slow