### PR TITLE
Add electron-log dependency for improved Core logging

### DIFF
--- a/StratisCore.UI/main.ts
+++ b/StratisCore.UI/main.ts
@@ -2,10 +2,14 @@ import { app, BrowserWindow, ipcMain, Menu, nativeImage, Tray } from 'electron';
 import * as path from 'path';
 import * as url from 'url';
 import * as os from 'os';
+import * as log from "electron-log";
 
 if (os.arch() === 'arm') {
   app.disableHardwareAcceleration();
 }
+
+// Set the log level to info. This is only for logging in this Electron main process.
+log.transports.file.level = 'info';
 
 // Set to true if you want to build Core for sidechains
 const buildForSidechain = false;
@@ -21,7 +25,7 @@ const args = process.argv.slice(1);
 
 args.push('--enableSignalR');
 
-console.log(args);
+writeLog('Startup with arguments: ', args);
 
 serve = args.some(val => val === '--serve' || val === '-serve');
 testnet = args.some(val => val === '--testnet' || val === '-testnet');
@@ -144,7 +148,7 @@ function createWindow() {
 // Some APIs can only be used after this event occurs.
 app.on('ready', () => {
   if (serve) {
-    console.log('Stratis UI was started in development mode. This requires the user to be running the Stratis Full Node Daemon himself.');
+    writeLog('Stratis UI was started in development mode. This requires the user to be running the Stratis Full Node Daemon himself.')
   } else {
     if (!nodaemon) {
       startDaemon();
@@ -228,8 +232,8 @@ function startDaemon() {
   const spawnArgs = args.filter(arg => arg.startsWith('-'))
     .join('&').replace(/--/g, '-').split('&');
 
-  console.log('Starting daemon ' + daemonPath);
-  console.log(spawnArgs);
+  writeLog('Starting daemon:', daemonPath);
+  writeLog('Spawn arguments:', spawnArgs);
 
   daemonProcess = spawnDaemon(daemonPath, spawnArgs, {
     detached: true
@@ -287,8 +291,19 @@ function createTray() {
   });
 }
 
-function writeLog(msg) {
-  console.log(msg);
+function writeDebug(msg, ...params: any[]) {
+  console.log(msg, ...params);
+  log.debug(msg, ...params);
+}
+
+function writeLog(msg, ...params: any[]) {
+  console.log(msg, ...params);
+  log.info(msg, ...params);
+}
+
+function writeError(msg, ...params: any[]) {
+  console.error(msg, ...params);
+  log.error(msg, ...params);
 }
 
 function createMenu() {

--- a/StratisCore.UI/package.json
+++ b/StratisCore.UI/package.json
@@ -62,9 +62,10 @@
   "dependencies": {
     "@aspnet/signalr": "^1.1.4",
     "electron-context-menu": "0.14.0",
+    "electron-log": "3.0.9",
+    "minimist": "1.2.0",
     "ngx-pagination": "4.1.0",
-    "ngx-qrcode2": "0.0.9",
-    "minimist": "1.2.0"
+    "ngx-qrcode2": "0.0.9"
   },
   "devDependencies": {
     "@angular-devkit/build-angular": "0.803.0",


### PR DESCRIPTION
- Add the electron-log as a dependency and replaces console logging with disk log for Electron main logic.
- Logs are written in "log.log" within the folder that contains cached data for the Electron (Chromium) app.
- To keep the PR minimal, no additional logging other than existing logging, has been added. Additional logging should be added to help debugging issues, especially smart to have more logging around Full node interactions.