### PR TITLE
fix multiple tokens

### DIFF
--- a/StratisCore.UI/src/app/wallet/tokens/services/tokens.service.ts
+++ b/StratisCore.UI/src/app/wallet/tokens/services/tokens.service.ts
@@ -1,6 +1,5 @@
 import { Injectable } from '@angular/core';
 import { LocalExecutionResult } from '@shared/models/local-execution-result';
-import { ApiService } from '@shared/services/api.service';
 import { Observable } from 'rxjs';
 import { map } from 'rxjs/operators';
 
@@ -26,18 +25,17 @@ export class TokensService {
       this.UpdateTokens(oldTokens);
       this.storage.removeItem('savedTokens');
     }
-   }
+  }
 
   GetSavedTokens(): SavedToken[] {
     const savedTokens = this.storage.getItem<SavedToken[]>(this.savedTokens);
-    return savedTokens ? [...this.defaultTokens, ...savedTokens] : this.defaultTokens;
+    return savedTokens ? this.defaultTokens.concat(savedTokens) : this.defaultTokens;
   }
 
   GetAvailableTokens(): Token[] {
     return [
-      new Token('CG1', 'CXa9fNVXPfYL9rdqiR22NoAc9kZUfBAUCu', 'Cirrus Giveaway'),
-      ...this.defaultTokens
-    ];
+      new Token('CG1', 'CXa9fNVXPfYL9rdqiR22NoAc9kZUfBAUCu', 'Cirrus Giveaway')
+    ].concat(this.defaultTokens);
   }
 
   UpdateTokens(tokens: SavedToken[]): Result<SavedToken[]> {
@@ -46,11 +44,15 @@ export class TokensService {
   }
 
   AddToken(token: SavedToken): Result<SavedToken> {
-    if (!token) { return new Result(ResultStatus.Error, 'Invalid token'); }
+    if (!token) {
+      return new Result(ResultStatus.Error, 'Invalid token');
+    }
     const tokens = this.GetSavedTokens();
 
     const index = tokens.map(t => t.address).indexOf(token.address);
-    if (index >= 0) { return new Result(ResultStatus.Error, 'Specified token is already saved'); }
+    if (index >= 0) {
+      return new Result(ResultStatus.Error, 'Specified token is already saved');
+    }
 
     tokens.push(token);
     this.storage.setItem(this.savedTokens, tokens);
@@ -58,10 +60,14 @@ export class TokensService {
   }
 
   RemoveToken(token: SavedToken): Result<SavedToken> {
-    if (!token) { return new Result(ResultStatus.Error, 'Invalid token'); }
+    if (!token) {
+      return new Result(ResultStatus.Error, 'Invalid token');
+    }
     const tokens = this.GetSavedTokens();
     const index = tokens.map(t => t.address).indexOf(token.address);
-    if (index < 0) { return new Result(ResultStatus.Error, 'Specified token was not found'); }
+    if (index < 0) {
+      return new Result(ResultStatus.Error, 'Specified token was not found');
+    }
     tokens.splice(index, 1);
     this.storage.setItem(this.savedTokens, tokens);
     return Result.ok(token);


### PR DESCRIPTION
The PR fixes the issue when issuing a token creates multiple instances.

This was a strange bug as it did not happen in dev mode. But was due to using the ... operator to combine array instances which then had the same reference with the defaultTokens object.