### PR TITLE
Add decimal support

### DIFF
--- a/StratisCore.UI/package.json
+++ b/StratisCore.UI/package.json
@@ -61,10 +61,11 @@
   },
   "dependencies": {
     "@aspnet/signalr": "^1.1.4",
+    "bignumber.js": "^9.0.0",
     "electron-context-menu": "0.14.0",
+    "minimist": "1.2.0",
     "ngx-pagination": "4.1.0",
-    "ngx-qrcode2": "0.0.9",
-    "minimist": "1.2.0"
+    "ngx-qrcode2": "0.0.9"
   },
   "devDependencies": {
     "@angular-devkit/build-angular": "0.803.0",

--- a/StratisCore.UI/package.json
+++ b/StratisCore.UI/package.json
@@ -1,7 +1,7 @@
 {
   "name": "stratis-core",
   "description": "Stratis Core Wallet",
-  "version": "1.3.0",
+  "version": "1.3.2",
   "author": {
     "name": "Stratis Group Ltd.",
     "email": "support@stratisplatform.com"

--- a/StratisCore.UI/package.json
+++ b/StratisCore.UI/package.json
@@ -63,6 +63,7 @@
     "@aspnet/signalr": "^1.1.4",
     "bignumber.js": "^9.0.0",
     "electron-context-menu": "0.14.0",
+    "json-bignumber": "^1.0.2",
     "minimist": "1.2.0",
     "ngx-pagination": "4.1.0",
     "ngx-qrcode2": "0.0.9"

--- a/StratisCore.UI/src/app/shared/services/api.service.ts
+++ b/StratisCore.UI/src/app/shared/services/api.service.ts
@@ -284,7 +284,7 @@ export class ApiService extends RestApi implements IApiService {
 
   // Returns local call data as raw text so we can parse it correctly later
   public localCallRaw(localCall: TokenBalanceRequest): Observable<string> {
-    return this.httpClient.post<string>(`${this.API_URL}/smartcontracts/local-call`, localCall, {
+    return this.httpClient.post(`${this.API_URL}/smartcontracts/local-call`, localCall, {
       ...this.getHttpOptions('application/json', 'application/json'),
       responseType: 'text'
     }).pipe(

--- a/StratisCore.UI/src/app/shared/services/api.service.ts
+++ b/StratisCore.UI/src/app/shared/services/api.service.ts
@@ -282,6 +282,16 @@ export class ApiService extends RestApi implements IApiService {
     );
   }
 
+  // Returns local call data as raw text so we can parse it correctly later
+  public localCallRaw(localCall: TokenBalanceRequest): Observable<string> {
+    return this.httpClient.post<string>(`${this.API_URL}/smartcontracts/local-call`, localCall, {
+      ...this.getHttpOptions('application/json', 'application/json'),
+      responseType: 'text'
+    }).pipe(
+      catchError(err => this.handleHttpError(err))
+    );
+  }
+
   private getWalletParams(walletInfo: WalletInfo, extra?: { [key: string]: string }): HttpParams {
     let params = new HttpParams()
       .set('walletName', walletInfo.walletName)

--- a/StratisCore.UI/src/app/shared/services/global.service.ts
+++ b/StratisCore.UI/src/app/shared/services/global.service.ts
@@ -15,7 +15,7 @@ export class GlobalService {
     this.setDaemonIP();
   }
 
-  private applicationVersion = '1.3.0';
+  private applicationVersion = '1.3.2';
   private testnet = false;
   private sidechain = false;
   private mainApiPort = 37221;

--- a/StratisCore.UI/src/app/wallet/smart-contracts/components/modals/transaction/transaction.component.html
+++ b/StratisCore.UI/src/app/wallet/smart-contracts/components/modals/transaction/transaction.component.html
@@ -110,7 +110,7 @@
               <p *ngIf="tokenSymbol.errors.required">Token symbol is required</p>
             </div>
           </div>
-          <div class="form-group col-6 clearfix" data-toggle="tooltip" data-placement="right" title="Total coin supply">
+          <div class="form-group col-6 clearfix" data-toggle="tooltip" data-placement="right" title="Total coin supply. If decimals is provided, this value will be scaled.">
             <label for="totalSupply">Total Supply</label>
             <input formControlName="totalSupply" id="totalSupply" type="number" class="form-control"
               placeholder="Total Supply"
@@ -118,6 +118,17 @@
             <div *ngIf="totalSupply.errors" class="invalid-feedback">
               <p *ngIf="totalSupply.errors.required">Total supply is required</p>
               <p *ngIf="totalSupply.errors.min">Total supply cannot be negative or zero</p>
+            </div>
+          </div>
+          <div class="form-group col-6 clearfix" data-toggle="tooltip" data-placement="right" title="The number of decimal places your token has after the 0 eg. 0.12345 has 5 decimal places">
+            <label for="totalSupply">Decimal Places</label>
+            <input formControlName="decimals" id="decimals" type="number" class="form-control"
+              placeholder="Decimals"
+              [class.is-invalid]="decimals.invalid && (decimals.dirty || decimals.touched)" min="0">
+            <div *ngIf="decimals.errors" class="invalid-feedback">
+              <p *ngIf="decimals.errors.required">Decimal places is required</p>
+              <p *ngIf="decimals.errors.min">Decimal places cannot be negative or zero</p>
+              <p *ngIf="decimals.errors.max">Decimal places must be 8 or less</p>
             </div>
           </div>
         </div>

--- a/StratisCore.UI/src/app/wallet/smart-contracts/components/modals/transaction/transaction.component.html
+++ b/StratisCore.UI/src/app/wallet/smart-contracts/components/modals/transaction/transaction.component.html
@@ -130,6 +130,7 @@
               <p *ngIf="decimals.errors.required">Decimal places is required</p>
               <p *ngIf="decimals.errors.min">Decimal places cannot be negative or zero</p>
               <p *ngIf="decimals.errors.max">Decimal places must be 8 or less</p>
+              <p *ngIf="decimals.errors.pattern">Decimal places must be an integer</p>
             </div>
           </div>
         </div>

--- a/StratisCore.UI/src/app/wallet/smart-contracts/components/modals/transaction/transaction.component.html
+++ b/StratisCore.UI/src/app/wallet/smart-contracts/components/modals/transaction/transaction.component.html
@@ -112,7 +112,7 @@
           </div>
           <div class="form-group col-6 clearfix" data-toggle="tooltip" data-placement="right" title="Total coin supply. If decimals is provided, this value will be scaled.">
             <label for="totalSupply">Total Supply</label>
-            <input formControlName="totalSupply" id="totalSupply" type="number" class="form-control"
+            <input formControlName="totalSupply" id="totalSupply" type="text" class="form-control"
               placeholder="Total Supply"
               [class.is-invalid]="totalSupply.invalid && (totalSupply.dirty || totalSupply.touched)" min="0">
             <div *ngIf="totalSupply.errors" class="invalid-feedback">

--- a/StratisCore.UI/src/app/wallet/smart-contracts/components/modals/transaction/transaction.component.html
+++ b/StratisCore.UI/src/app/wallet/smart-contracts/components/modals/transaction/transaction.component.html
@@ -118,6 +118,7 @@
             <div *ngIf="totalSupply.errors" class="invalid-feedback">
               <p *ngIf="totalSupply.errors.required">Total supply is required</p>
               <p *ngIf="totalSupply.errors.min">Total supply cannot be negative or zero</p>
+              <p *ngIf="totalSupply.errors.pattern">Total supply must be an integer</p>
             </div>
           </div>
           <div class="form-group col-6 clearfix" data-toggle="tooltip" data-placement="right" title="The number of decimal places your token has after the 0 eg. 0.12345 has 5 decimal places">
@@ -131,6 +132,9 @@
               <p *ngIf="decimals.errors.max">Decimal places must be 8 or less</p>
             </div>
           </div>
+        </div>
+        <div *ngIf="transactionForm.errors">
+          <p *ngIf="transactionForm.errors.maxSupplyTooLargeError" class="text-danger">Total supply * 10^(decimal places) cannot exceed 18,400,000,000,000,000,000</p>
         </div>
       </ng-template>
       <div class="mt-2 mb-4 d-flex justify-content-end" *ngIf="mode !== modeEnum.IssueToken">

--- a/StratisCore.UI/src/app/wallet/smart-contracts/components/modals/transaction/transaction.component.ts
+++ b/StratisCore.UI/src/app/wallet/smart-contracts/components/modals/transaction/transaction.component.ts
@@ -240,7 +240,7 @@ export class TransactionComponent implements OnInit {
     this.contractCode = new FormControl(contractCode, [Validators.required, Validators.nullValidator, Validators.pattern('[0-9a-fA-F]*'), oddValidator]);
     this.parameters = new FormArray([]);
     this.password = new FormControl('', [Validators.required, Validators.nullValidator]);
-    this.decimals = new FormControl(0, [Validators.min(0), Validators.max(8), Validators.required]);
+    this.decimals = new FormControl(0, [Validators.min(0), Validators.max(8), integerValidator, Validators.required]);
 
     this.totalSupply = new FormControl(21 * 1000 * 1000, [Validators.min(1), Validators.max(ULONG_MAXVALUE), integerValidator, Validators.required]);
     this.tokenName = new FormControl('My token', [Validators.required]);

--- a/StratisCore.UI/src/app/wallet/smart-contracts/components/modals/transaction/transaction.component.ts
+++ b/StratisCore.UI/src/app/wallet/smart-contracts/components/modals/transaction/transaction.component.ts
@@ -138,7 +138,10 @@ export class TransactionComponent implements OnInit {
   private createModel() {
 
     if (this.mode === Mode.IssueToken) {
-      let totalSupply = this.totalSupply.value * 10 ** this.decimals.value;
+      // TotalSupply is represented as a string to ensure large numbers
+      // don't fall victim to JavaScript's rounding. Therefore we need to scale
+      // by the decimal amount using this strategy.
+      let totalSupply = this.totalSupply.value + "0".repeat(this.decimals.value);
 
       return {
         amount: this.amount.value,

--- a/StratisCore.UI/src/app/wallet/smart-contracts/components/modals/transaction/transaction.component.ts
+++ b/StratisCore.UI/src/app/wallet/smart-contracts/components/modals/transaction/transaction.component.ts
@@ -50,6 +50,7 @@ export class TransactionComponent implements OnInit {
   contractCode: FormControl;
   password: FormControl;
   totalSupply: FormControl;
+  decimals: FormControl;
   tokenName: FormControl;
   tokenSymbol: FormControl;
   coinUnit: string;
@@ -118,7 +119,7 @@ export class TransactionComponent implements OnInit {
       .toPromise()
       .then(transactionHash => {
         this.loading = false;
-        this.activeModal.close({ symbol: this.tokenSymbol.value.toUpperCase(), name: this.tokenName.value, transactionHash });
+        this.activeModal.close({ symbol: this.tokenSymbol.value.toUpperCase(), name: this.tokenName.value, transactionHash, decimals: this.decimals.value });
       },
         error => {
           this.loading = false;
@@ -137,13 +138,15 @@ export class TransactionComponent implements OnInit {
   private createModel() {
 
     if (this.mode === Mode.IssueToken) {
+      let totalSupply = this.totalSupply.value * 10 ** this.decimals.value;
+
       return {
         amount: this.amount.value,
         feeAmount: this.feeAmount.value,
         gasPrice: this.gasPrice.value,
         gasLimit: this.gasLimit.value,
         parameters: [
-          `7#${this.totalSupply.value}`,
+          `7#${totalSupply}`,
           `4#${this.tokenName.value}`,
           `4#${this.tokenSymbol.value.toUpperCase()}`
         ],
@@ -204,6 +207,7 @@ export class TransactionComponent implements OnInit {
     this.parameters = new FormArray([]);
     this.password = new FormControl('', [Validators.required, Validators.nullValidator]);
     this.totalSupply = new FormControl(21 * 1000 * 1000, [Validators.min(1), Validators.required]);
+    this.decimals = new FormControl(0, [Validators.min(0), Validators.max(8), Validators.required]);
     this.tokenName = new FormControl('My token', [Validators.required]);
     this.tokenSymbol = new FormControl('MTK', [Validators.required]);
 
@@ -239,7 +243,8 @@ export class TransactionComponent implements OnInit {
         password: this.password,
         totalSupply: this.totalSupply,
         tokenName: this.tokenName,
-        tokenSymbol: this.tokenSymbol
+        tokenSymbol: this.tokenSymbol,
+        decimals: this.decimals
       });
     }
   }

--- a/StratisCore.UI/src/app/wallet/tokens/components/add-token/add-token.component.html
+++ b/StratisCore.UI/src/app/wallet/tokens/components/add-token/add-token.component.html
@@ -57,6 +57,7 @@
           <p *ngIf="decimals.errors['required']">Number of decimals is required</p>
           <p *ngIf="decimals.errors['min']">Number of decimals must be 0 or more</p>
           <p *ngIf="decimals.errors['max']">Number of decimals must be 8 or less</p>
+          <p *ngIf="decimals.errors.pattern">Decimal places must be an integer</p>
         </div>
       </div>
       <div *ngIf="apiError" class="text-danger">{{ apiError }}</div>

--- a/StratisCore.UI/src/app/wallet/tokens/components/add-token/add-token.component.html
+++ b/StratisCore.UI/src/app/wallet/tokens/components/add-token/add-token.component.html
@@ -54,9 +54,9 @@
         <input formControlName="decimals" id="decimals" type="number" class="form-control" placeholder="" step="1"
           [class.is-invalid]="decimals.invalid && (decimals.dirty || decimals.touched)" maxlength="2">
         <div *ngIf="decimals.errors" class="invalid-feedback">
-          <p *ngIf="decimals.errors['required']">Number of decimals is required</p>
-          <p *ngIf="decimals.errors['min']">Number of decimals must be 0 or more</p>
-          <p *ngIf="decimals.errors['max']">Number of decimals must be 8 or less</p>
+          <p *ngIf="decimals.errors.required">Number of decimals is required</p>
+          <p *ngIf="decimals.errors.min">Number of decimals must be 0 or more</p>
+          <p *ngIf="decimals.errors.max">Number of decimals must be 8 or less</p>
           <p *ngIf="decimals.errors.pattern">Decimal places must be an integer</p>
         </div>
       </div>

--- a/StratisCore.UI/src/app/wallet/tokens/components/add-token/add-token.component.html
+++ b/StratisCore.UI/src/app/wallet/tokens/components/add-token/add-token.component.html
@@ -48,6 +48,17 @@
           <p *ngIf="name.errors['required']">Token name is required</p>
         </div>
       </div>
+      <div class="form-group clearfix" data-toggle="tooltip" data-placement="right" title="Token name"
+        *ngIf="customTokenSelected">
+        <label for="name">Token Decimals</label>
+        <input formControlName="decimals" id="decimals" type="number" class="form-control" placeholder="" step="1"
+          [class.is-invalid]="decimals.invalid && (decimals.dirty || decimals.touched)" maxlength="2">
+        <div *ngIf="decimals.errors" class="invalid-feedback">
+          <p *ngIf="decimals.errors['required']">Number of decimals is required</p>
+          <p *ngIf="decimals.errors['min']">Number of decimals must be 0 or more</p>
+          <p *ngIf="decimals.errors['max']">Number of decimals must be 8 or less</p>
+        </div>
+      </div>
       <div *ngIf="apiError" class="text-danger">{{ apiError }}</div>
     </div>
     <div class="modal-footer">

--- a/StratisCore.UI/src/app/wallet/tokens/components/add-token/add-token.component.ts
+++ b/StratisCore.UI/src/app/wallet/tokens/components/add-token/add-token.component.ts
@@ -114,12 +114,13 @@ export class AddTokenComponent implements OnInit, OnDestroy, Disposable {
 
   private registerControls() {
     const customTokenDetailsValidator = control => !control.value && this.customTokenSelected ? { required: true } : null;
+    const integerValidator = Validators.pattern('^[0-9][0-9]*$');
 
     this.token = new FormControl(0, [Validators.required]);
     this.address = new FormControl('', [customTokenDetailsValidator]);
     this.ticker = new FormControl('', [customTokenDetailsValidator]);
     this.name = new FormControl('', [customTokenDetailsValidator]);
-    this.decimals = new FormControl(0, [Validators.required, Validators.min(0), Validators.max(8)]);
+    this.decimals = new FormControl(0, [Validators.required, Validators.min(0), integerValidator, Validators.max(8)]);
 
     this.addTokenForm = new FormGroup({
       token: this.token,

--- a/StratisCore.UI/src/app/wallet/tokens/components/add-token/add-token.component.ts
+++ b/StratisCore.UI/src/app/wallet/tokens/components/add-token/add-token.component.ts
@@ -96,7 +96,7 @@ export class AddTokenComponent implements OnInit, OnDestroy, Disposable {
           return;
         }
 
-        const savedToken = new SavedToken(ticker, address, 0, name, decimals);
+        const savedToken = new SavedToken(ticker, address, "0", name, decimals);
         const result = this.tokenService.AddToken(savedToken);
 
         if (result.failure) {

--- a/StratisCore.UI/src/app/wallet/tokens/components/add-token/add-token.component.ts
+++ b/StratisCore.UI/src/app/wallet/tokens/components/add-token/add-token.component.ts
@@ -25,6 +25,7 @@ export class AddTokenComponent implements OnInit, OnDestroy, Disposable {
   token: FormControl;
   address: FormControl;
   ticker: FormControl;
+  decimals: FormControl;
   name: FormControl;
   loading: boolean;
   apiError: string;
@@ -58,6 +59,7 @@ export class AddTokenComponent implements OnInit, OnDestroy, Disposable {
     const ticker = this.customTokenSelected ? this.ticker.value + '' : this.tokens.find(t => t.address === this.token.value).ticker;
     const address = this.customTokenSelected ? this.address.value + '' : this.tokens.find(t => t.address === this.token.value).address;
     const name = this.customTokenSelected ? this.name.value + '' : this.tokens.find(t => t.address === this.token.value).name;
+    const decimals = this.customTokenSelected ? this.decimals.value : this.tokens.find(t => t.address === this.token.value.decimals);
 
     // Check that this token isn't already in the list
     const addedTokens = this.tokenService.GetSavedTokens().find(token => token.address === address);
@@ -94,7 +96,7 @@ export class AddTokenComponent implements OnInit, OnDestroy, Disposable {
           return;
         }
 
-        const savedToken = new SavedToken(ticker, address, 0, name);
+        const savedToken = new SavedToken(ticker, address, 0, name, decimals);
         const result = this.tokenService.AddToken(savedToken);
 
         if (result.failure) {
@@ -117,12 +119,14 @@ export class AddTokenComponent implements OnInit, OnDestroy, Disposable {
     this.address = new FormControl('', [customTokenDetailsValidator]);
     this.ticker = new FormControl('', [customTokenDetailsValidator]);
     this.name = new FormControl('', [customTokenDetailsValidator]);
+    this.decimals = new FormControl(0, [Validators.required, Validators.min(0), Validators.max(8)]);
 
     this.addTokenForm = new FormGroup({
       token: this.token,
       address: this.address,
       ticker: this.ticker,
-      name: this.name
+      name: this.name,
+      decimals: this.decimals
     });
   }
 }

--- a/StratisCore.UI/src/app/wallet/tokens/components/send-token/send-token.component.html
+++ b/StratisCore.UI/src/app/wallet/tokens/components/send-token/send-token.component.html
@@ -64,7 +64,7 @@
       </div>
       <div class="float-right">Balance: 
         <span class="btn-link no-underline">
-          <strong data-toggle="tooltip" data-placement="right" [title]="token.formattedBalance + ' ' + token.ticker" (click)="setTokenAmount(token.formattedBalance)">{{ token.formattedBalance }}</strong><small> {{ token.ticker }}</small>
+          <strong data-toggle="tooltip" data-placement="right" [title]="token.balance + ' ' + token.ticker" (click)="setTokenAmount(token.balance)">{{ token.balance }}</strong><small> {{ token.ticker }}</small>
         </span>
       </div>
       <div class="form-group clearfix" data-toggle="tooltip" data-placement="right"
@@ -75,7 +75,7 @@
           min="0">
         <div *ngIf="tokenAmount.errors" class="invalid-feedback">
           <p *ngIf="tokenAmount.errors['min']">The number of tokens cannot be negative</p>
-          <p *ngIf="tokenAmount.errors['max']">The number of tokens exceeds your balance of {{ token.formattedBalance }} {{ token.ticker }}</p>
+          <p *ngIf="tokenAmount.errors['max']">The number of tokens exceeds your balance of {{ token.balance }} {{ token.ticker }}</p>
           <p *ngIf="tokenAmount.errors['pattern']">The number of decimal places must be {{ token.decimals }} or less</p>
         </div>
       </div>

--- a/StratisCore.UI/src/app/wallet/tokens/components/send-token/send-token.component.html
+++ b/StratisCore.UI/src/app/wallet/tokens/components/send-token/send-token.component.html
@@ -64,18 +64,19 @@
       </div>
       <div class="float-right">Balance: 
         <span class="btn-link no-underline">
-          <strong data-toggle="tooltip" data-placement="right" [title]="token.balance + ' ' + token.ticker" (click)="setTokenAmount(token.balance)">{{ token.balance }}</strong><small> {{ token.ticker }}</small>
+          <strong data-toggle="tooltip" data-placement="right" [title]="token.formattedBalance + ' ' + token.ticker" (click)="setTokenAmount(token.formattedBalance)">{{ token.formattedBalance }}</strong><small> {{ token.ticker }}</small>
         </span>
       </div>
       <div class="form-group clearfix" data-toggle="tooltip" data-placement="right"
         title="The amount of tokens to send">
         <label for="amount">Number of Tokens To Send</label>
-        <input formControlName="tokenAmount" id="tokenAmount" type="number" step="1" class="form-control"
+        <input formControlName="tokenAmount" id="tokenAmount" type="text" class="form-control"
           placeholder="Amount" [class.is-invalid]="tokenAmount.invalid && (tokenAmount.dirty || tokenAmount.touched)"
           min="0">
         <div *ngIf="tokenAmount.errors" class="invalid-feedback">
           <p *ngIf="tokenAmount.errors['min']">The number of tokens cannot be negative</p>
-          <p *ngIf="tokenAmount.errors['max']">The number of tokens exceeds your balance of {{ token.balance }} {{ token.ticker }}</p>
+          <p *ngIf="tokenAmount.errors['max']">The number of tokens exceeds your balance of {{ token.formattedBalance }} {{ token.ticker }}</p>
+          <p *ngIf="tokenAmount.errors['pattern']">The number of decimal places must be {{ token.decimals }} or less</p>
         </div>
       </div>
 

--- a/StratisCore.UI/src/app/wallet/tokens/components/send-token/send-token.component.ts
+++ b/StratisCore.UI/src/app/wallet/tokens/components/send-token/send-token.component.ts
@@ -69,7 +69,7 @@ export class SendTokenComponent implements OnInit {
       gasLimit: this.gasLimit.value,
       parameters: [
         `9#${this.recipientAddress.value}`,
-        `7#${this.token.toScaledAmount(this.tokenAmount.value)}`
+        `7#${this.token.toScaledAmount(this.tokenAmount.value).toFixed()}`
       ],
       methodName: 'TransferTo',
       password: this.password.value,
@@ -125,7 +125,7 @@ export class SendTokenComponent implements OnInit {
 
     const gasLimitValidator = (gasCallLimitMinimumValidator);
 
-    this.tokenAmount = new FormControl(0, [Validators.required, Validators.min(0), Validators.max(this.token.balance), decimalPlaceValidator]);
+    this.tokenAmount = new FormControl(0, [Validators.required, Validators.min(0), Validators.max(Number(this.token.balance)), decimalPlaceValidator]);
     this.feeAmount = new FormControl(0.001, [Validators.required, amountValidator, Validators.min(0)]);
     // tslint:disable-next-line:max-line-length
     this.gasPrice = new FormControl(100, [Validators.required, integerValidator, Validators.pattern('^[+]?([0-9]{0,})*[.]?([0-9]{0,2})?$'), gasPriceTooLowValidator, gasPriceTooHighValidator, Validators.min(0)]);

--- a/StratisCore.UI/src/app/wallet/tokens/components/send-token/send-token.component.ts
+++ b/StratisCore.UI/src/app/wallet/tokens/components/send-token/send-token.component.ts
@@ -69,7 +69,7 @@ export class SendTokenComponent implements OnInit {
       gasLimit: this.gasLimit.value,
       parameters: [
         `9#${this.recipientAddress.value}`,
-        `7#${this.tokenAmount.value}`
+        `7#${this.token.toScaledAmount(this.tokenAmount.value)}`
       ],
       methodName: 'TransferTo',
       password: this.password.value,
@@ -107,7 +107,7 @@ export class SendTokenComponent implements OnInit {
         });
   }
 
-  setTokenAmount(tokenBalance: number) {
+  setTokenAmount(tokenBalance: string) {
     this.tokenAmount.setValue(tokenBalance);
   }
 
@@ -121,9 +121,11 @@ export class SendTokenComponent implements OnInit {
 
     const integerValidator = Validators.pattern('^[0-9][0-9]*$');
 
+    const decimalPlaceValidator = Validators.pattern('^[0-9]+(\.[0-9]{0,' + this.token.decimals + '})?$');
+
     const gasLimitValidator = (gasCallLimitMinimumValidator);
 
-    this.tokenAmount = new FormControl(0, [Validators.required, Validators.min(0), Validators.max(this.token.balance)]);
+    this.tokenAmount = new FormControl(0, [Validators.required, Validators.min(0), Validators.max(this.token.balance), decimalPlaceValidator]);
     this.feeAmount = new FormControl(0.001, [Validators.required, amountValidator, Validators.min(0)]);
     // tslint:disable-next-line:max-line-length
     this.gasPrice = new FormControl(100, [Validators.required, integerValidator, Validators.pattern('^[+]?([0-9]{0,})*[.]?([0-9]{0,2})?$'), gasPriceTooLowValidator, gasPriceTooHighValidator, Validators.min(0)]);

--- a/StratisCore.UI/src/app/wallet/tokens/components/tokens.component.html
+++ b/StratisCore.UI/src/app/wallet/tokens/components/tokens.component.html
@@ -71,7 +71,7 @@
                 <td class="text-center col-1" scope="col"><span class="badge badge-info">{{item.ticker}}</span></td>
                 <td class="text-left col-2" scope="col">{{ item.name }}</td>
                 <td class="text-left col-2" scope="col">
-                  {{ item.balance === null && tokenLoading[item.address] === 'loading' ? 'Loading...' : item.balance }}
+                  {{ !item.hasBalance() && tokenLoading[item.address] === 'loading' ? 'Loading...' : item.balance }}
                 </td>
                 <td class="text-left col-5" scope="col">
                   {{ item.address }}

--- a/StratisCore.UI/src/app/wallet/tokens/components/tokens.component.html
+++ b/StratisCore.UI/src/app/wallet/tokens/components/tokens.component.html
@@ -71,7 +71,7 @@
                 <td class="text-center col-1" scope="col"><span class="badge badge-info">{{item.ticker}}</span></td>
                 <td class="text-left col-2" scope="col">{{ item.name }}</td>
                 <td class="text-left col-2" scope="col">
-                  {{ item.balance === null && tokenLoading[item.address] === 'loading' ? 'Loading...' : item.balance }}
+                  {{ item.balance === null && tokenLoading[item.address] === 'loading' ? 'Loading...' : item.formattedBalance }}
                 </td>
                 <td class="text-left col-5" scope="col">
                   {{ item.address }}

--- a/StratisCore.UI/src/app/wallet/tokens/components/tokens.component.html
+++ b/StratisCore.UI/src/app/wallet/tokens/components/tokens.component.html
@@ -71,7 +71,7 @@
                 <td class="text-center col-1" scope="col"><span class="badge badge-info">{{item.ticker}}</span></td>
                 <td class="text-left col-2" scope="col">{{ item.name }}</td>
                 <td class="text-left col-2" scope="col">
-                  {{ item.balance === null && tokenLoading[item.address] === 'loading' ? 'Loading...' : item.formattedBalance }}
+                  {{ item.balance === null && tokenLoading[item.address] === 'loading' ? 'Loading...' : item.balance }}
                 </td>
                 <td class="text-left col-5" scope="col">
                   {{ item.address }}

--- a/StratisCore.UI/src/app/wallet/tokens/components/tokens.component.ts
+++ b/StratisCore.UI/src/app/wallet/tokens/components/tokens.component.ts
@@ -221,7 +221,7 @@ export class TokensComponent implements OnInit, OnDestroy, Disposable {
         .subscribe(
           receipt => {
             const newTokenAddress = receipt['newContractAddress'];
-            const token = new SavedToken(value.symbol, newTokenAddress, 0, value.name);
+            const token = new SavedToken(value.symbol, newTokenAddress, 0, value.name, value.decimals);
             this.tokenService.AddToken(token);
             progressModal.close('ok');
             this.tokens.push(token);

--- a/StratisCore.UI/src/app/wallet/tokens/components/tokens.component.ts
+++ b/StratisCore.UI/src/app/wallet/tokens/components/tokens.component.ts
@@ -92,7 +92,7 @@ export class TokensComponent implements OnInit, OnDestroy, Disposable {
     // Update requested token balances
     this.tokenBalanceRefreshRequested$
       .pipe(
-        tap(tokensToReload => tokensToReload.forEach(t => t.balance = null)),
+        tap(tokensToReload => tokensToReload.forEach(t => t.clearBalance())),
         switchMap(tokensToReload => this.updateTokenBalances(tokensToReload)),
         takeUntil(this.disposed$)
       )
@@ -119,14 +119,14 @@ export class TokensComponent implements OnInit, OnDestroy, Disposable {
         }),
         tap(balance => {
           if (balance === null) {
-            token.balance = null;
+            token.clearBalance();
             this.tokenLoading[token.address] = 'error';
             return;
           }
 
           this.tokenLoading[token.address] = 'loaded';
           if (balance !== token.balance) {
-            token.balance = balance;
+            token.setBalance(balance);
           }
         }));
     }));
@@ -135,7 +135,7 @@ export class TokensComponent implements OnInit, OnDestroy, Disposable {
   ngOnInit() {
     // Clear all the balances to start with
     const tokens = this.tokenService.GetSavedTokens();
-    tokens.forEach(t => t.balance = null);
+    tokens.forEach(t => t.clearBalance());
     this.tokens = tokens;
 
     // Refresh them all

--- a/StratisCore.UI/src/app/wallet/tokens/components/tokens.component.ts
+++ b/StratisCore.UI/src/app/wallet/tokens/components/tokens.component.ts
@@ -221,7 +221,7 @@ export class TokensComponent implements OnInit, OnDestroy, Disposable {
         .subscribe(
           receipt => {
             const newTokenAddress = receipt['newContractAddress'];
-            const token = new SavedToken(value.symbol, newTokenAddress, 0, value.name, value.decimals);
+            const token = new SavedToken(value.symbol, newTokenAddress, "0", value.name, value.decimals);
             this.tokenService.AddToken(token);
             progressModal.close('ok');
             this.tokens.push(token);

--- a/StratisCore.UI/src/app/wallet/tokens/models/token.ts
+++ b/StratisCore.UI/src/app/wallet/tokens/models/token.ts
@@ -1,20 +1,53 @@
 export class Token {
-  constructor(ticker: string, address: string, name: string) {
+  constructor(ticker: string, address: string, name: string, decimals: number = 0) {
     this.ticker = ticker;
     this.address = address;
     this.name = name || this.ticker;
+    this.decimals = decimals;
   }
 
   ticker: string;
   address: string;
   name: string;
+  decimals: number;
 }
 
 export class SavedToken extends Token {
-  constructor(ticker: string, address: string, balance: number, name: string) {
-    super(ticker, address, name);
+  constructor(ticker: string, address: string, balance: number, name: string, decimals: number = 0) {
+    super(ticker, address, name, decimals);
     this.balance = balance;
   }
 
-  balance: number;
+  get balance(): number {
+    if (!this.decimals) {
+      return this._balance 
+    }
+
+    return this._balance / (10**this.decimals);
+  }
+
+  set balance(value: number){
+    this._balance = value;
+  }
+
+  get step() {
+    let s = 1/10**this.decimals;
+    return s.toFixed(this.decimals);
+  }
+
+  private _balance: number;
+
+  public toScaledAmount(amount: number): number {
+    if (this.decimals == null) {
+      return amount;
+    }
+
+    return amount * (10**this.decimals);
+  }
+
+  // Numbers less than 1e-6 will be formatted by javascript using scientific notation.
+  // Use this to get them into a readable format.
+  get formattedBalance(): string {
+    return (this.balance || 0).toFixed(this.decimals);
+  }
 }

--- a/StratisCore.UI/src/app/wallet/tokens/models/token.ts
+++ b/StratisCore.UI/src/app/wallet/tokens/models/token.ts
@@ -22,7 +22,7 @@ export class SavedToken extends Token {
 
   get balance(): string {
     if (!this.decimals) {
-      return this._balance.toString(); 
+      return this._balance.toFixed(); 
     }
 
     return this._balance.dividedBy(10**this.decimals).toFixed();

--- a/StratisCore.UI/src/app/wallet/tokens/models/token.ts
+++ b/StratisCore.UI/src/app/wallet/tokens/models/token.ts
@@ -41,10 +41,4 @@ export class SavedToken extends Token {
 
     return new BigNumber(amount).multipliedBy(10**this.decimals);
   }
-
-  // Numbers less than 1e-6 will be formatted by javascript using scientific notation.
-  // Use this to get them into a readable format.
-  get formattedBalance(): string {
-    return (this.balance || "0")
-  }
 }

--- a/StratisCore.UI/src/app/wallet/tokens/models/token.ts
+++ b/StratisCore.UI/src/app/wallet/tokens/models/token.ts
@@ -1,3 +1,5 @@
+import BigNumber from 'bignumber.js';
+
 export class Token {
   constructor(ticker: string, address: string, name: string, decimals: number = 0) {
     this.ticker = ticker;
@@ -13,41 +15,36 @@ export class Token {
 }
 
 export class SavedToken extends Token {
-  constructor(ticker: string, address: string, balance: number, name: string, decimals: number = 0) {
+  constructor(ticker: string, address: string, balance: string, name: string, decimals: number = 0) {
     super(ticker, address, name, decimals);
     this.balance = balance;
   }
 
-  get balance(): number {
+  get balance(): string {
     if (!this.decimals) {
-      return this._balance 
+      return this._balance.toString(); 
     }
 
-    return this._balance / (10**this.decimals);
+    return this._balance.dividedBy(10**this.decimals).toFixed();
   }
 
-  set balance(value: number){
-    this._balance = value;
+  set balance(value: string){
+    this._balance = new BigNumber(value);
   }
 
-  get step() {
-    let s = 1/10**this.decimals;
-    return s.toFixed(this.decimals);
-  }
+  private _balance: BigNumber;
 
-  private _balance: number;
-
-  public toScaledAmount(amount: number): number {
+  public toScaledAmount(amount: number): BigNumber {
     if (this.decimals == null) {
-      return amount;
+      return new BigNumber(amount);
     }
 
-    return amount * (10**this.decimals);
+    return new BigNumber(amount).multipliedBy(10**this.decimals);
   }
 
   // Numbers less than 1e-6 will be formatted by javascript using scientific notation.
   // Use this to get them into a readable format.
   get formattedBalance(): string {
-    return (this.balance || 0).toFixed(this.decimals);
+    return (this.balance || "0")
   }
 }

--- a/StratisCore.UI/src/app/wallet/tokens/models/token.ts
+++ b/StratisCore.UI/src/app/wallet/tokens/models/token.ts
@@ -17,19 +17,27 @@ export class Token {
 export class SavedToken extends Token {
   constructor(ticker: string, address: string, balance: string, name: string, decimals: number = 0) {
     super(ticker, address, name, decimals);
-    this.balance = balance;
+    this.setBalance(balance);
   }
 
   get balance(): string {
-    if (!this.decimals) {
-      return this._balance.toFixed(); 
+    if (!this._balance) {
+      return ""+0;
     }
 
-    return this._balance.dividedBy(10**this.decimals).toFixed();
+    return this._balance.toFixed();
   }
 
-  set balance(value: string){
-    this._balance = new BigNumber(value);
+  setBalance(balance: string) {
+    this._balance = new BigNumber(balance).dividedBy(10**this.decimals);
+  }
+
+  clearBalance() {
+    this._balance = null;
+  }
+
+  hasBalance() {
+    return this._balance !== null;
   }
 
   private _balance: BigNumber;

--- a/StratisCore.UI/src/app/wallet/tokens/services/tokens.service.ts
+++ b/StratisCore.UI/src/app/wallet/tokens/services/tokens.service.ts
@@ -29,9 +29,9 @@ export class TokensService {
 
   GetSavedTokens(): SavedToken[] {
     // Must map to the class here, just casting using getItem will not create the right object instance.
-    const savedTokens = this.storage.getItem<SavedToken[]>(this.savedTokens)
-      .map(t => new SavedToken(t.ticker, t.address, null, t.name, t.decimals));
-    return savedTokens ? [...this.defaultTokens, ...savedTokens] : this.defaultTokens;
+    const savedTokens = this.storage.getItem<SavedToken[]>(this.savedTokens);
+    var result = !!savedTokens ? [...this.defaultTokens, ...savedTokens] : [...this.defaultTokens];
+    return result.map(t => new SavedToken(t.ticker, t.address, null, t.name, t.decimals));
   }
 
   GetAvailableTokens(): Token[] {

--- a/StratisCore.UI/src/app/wallet/tokens/services/tokens.service.ts
+++ b/StratisCore.UI/src/app/wallet/tokens/services/tokens.service.ts
@@ -28,7 +28,9 @@ export class TokensService {
    }
 
   GetSavedTokens(): SavedToken[] {
-    const savedTokens = this.storage.getItem<SavedToken[]>(this.savedTokens);
+    // Must map to the class here, just casting using getItem will not create the right object instance.
+    const savedTokens = this.storage.getItem<SavedToken[]>(this.savedTokens)
+      .map(t => new SavedToken(t.ticker, t.address, null, t.name, t.decimals));
     return savedTokens ? [...this.defaultTokens, ...savedTokens] : this.defaultTokens;
   }
 

--- a/StratisCore.UI/src/app/wallet/tokens/services/tokens.service.ts
+++ b/StratisCore.UI/src/app/wallet/tokens/services/tokens.service.ts
@@ -3,7 +3,8 @@ import { LocalExecutionResult } from '@shared/models/local-execution-result';
 import { ApiService } from '@shared/services/api.service';
 import { Observable } from 'rxjs';
 import { map } from 'rxjs/operators';
-
+import JSONBigNumber from 'json-bignumber';
+import BigNumber from 'bignumber.js';
 import { LocalCallRequest } from '../models/LocalCallRequest';
 import { Result, ResultStatus } from '../models/result';
 import { SavedToken, Token } from '../models/token';
@@ -69,8 +70,19 @@ export class TokensService {
   }
 
   GetTokenBalance(request: TokenBalanceRequest): Observable<number> {
-    return this.LocalCall(request).pipe(
-      map(localExecutionresult => localExecutionresult.return ? localExecutionresult.return : 0)
+    return this.apiService.localCallRaw(request).pipe(
+      map(rawText => {
+        return JSONBigNumber.parse(rawText, function (key, value) {
+          if (key == "return") {
+            if(BigNumber.isBigNumber(value)) {
+              return value.toFixed();
+            }
+          } else {
+            return value;
+          }
+        });
+      }),
+      map(localExecutionresult => localExecutionresult.return ? localExecutionresult.return : "0")
     );
   }
 


### PR DESCRIPTION
Adds support for adding, creating and sending tokens with fractional/decimal values.

Decimals are purely a "UI" function and are achieved by scaling the supply of tokens by 10^(decimal places). The UI will display a decimal point where necessary.

The user must enter the number of decimal places to display in the UI when adding a token. When creating a token the supply is automatically scaled accordingly.