### PR TITLE
Move Transaction Mapping to Wallet Service

### DIFF
--- a/StratisCore.UI/src/app/shared/models/transaction-info.ts
+++ b/StratisCore.UI/src/app/shared/models/transaction-info.ts
@@ -21,27 +21,37 @@ export class TransactionInfo {
     public contact?: AddressLabel) {
   }
 
+  public get id(): string {
+    return this.transactionId;
+  }
+
+  public get timestamp(): number {
+    return this.transactionTimestamp;
+  }
+
   public static mapFromTransactionsHistoryItems(
     transactions: TransactionsHistoryItem[],
     maxTransactionCount?: number,
     addressBookService?: AddressBookService): TransactionInfo[] {
 
+    const toMap = maxTransactionCount ? transactions.slice(0, maxTransactionCount) : transactions;
+    return toMap.map(transaction => {
+        return this.mapFromTransactionsHistoryItem(transaction, addressBookService)
+      }
+    );
+  }
 
-    const mapped = transactions.map(transaction => {
-      const contact = addressBookService ? transaction.payments
-        .map(payment => addressBookService.findContactByAddress(payment.destinationAddress)).find(p => p != null) : null;
+  public static mapFromTransactionsHistoryItem(transaction: TransactionsHistoryItem, addressBookService?: AddressBookService): TransactionInfo {
+    const contact = addressBookService ? transaction.payments
+      .map(payment => addressBookService.findContactByAddress(payment.destinationAddress)).find(p => p != null) : null;
 
-      return new TransactionInfo(
-        transaction.type === 'send' ? 'sent' : transaction.type,
-        transaction.id,
-        transaction.amount,
-        transaction.fee || 0,
-        transaction.txOutputIndex,
-        transaction.confirmedInBlock,
-        transaction.timestamp, transaction.payments, transaction.toAddress, contact);
-    });
-
-    return maxTransactionCount ? mapped.slice(0, maxTransactionCount) : mapped;
-
+    return new TransactionInfo(
+      transaction.type === 'send' ? 'sent' : transaction.type,
+      transaction.id,
+      transaction.amount,
+      transaction.fee || 0,
+      transaction.txOutputIndex,
+      transaction.confirmedInBlock,
+      transaction.timestamp, transaction.payments, transaction.toAddress, contact);
   }
 }

--- a/StratisCore.UI/src/app/wallet/transactions/transactions.component.ts
+++ b/StratisCore.UI/src/app/wallet/transactions/transactions.component.ts
@@ -2,7 +2,7 @@ import { Component, EventEmitter, Input, OnDestroy, OnInit, Output } from '@angu
 import { TransactionInfo } from '@shared/models/transaction-info';
 import { GlobalService } from '@shared/services/global.service';
 import { Observable, Subscription } from 'rxjs';
-import { map, tap } from 'rxjs/operators';
+import { filter, map, tap } from 'rxjs/operators';
 import { WalletService } from '@shared/services/wallet.service';
 import { SnackbarService } from 'ngx-snackbar';
 import { AddressBookService } from '@shared/services/address-book-service';
@@ -60,18 +60,14 @@ export class TransactionsComponent implements OnInit, OnDestroy {
 
   public ngOnInit(): void {
     this.transactions = this.walletService.walletHistory()
-      .pipe(map((historyItems => {
-        return ((null != historyItems && historyItems.length > 0))
-          ? this.stakingOnly
-            // tslint:disable-next-line:max-line-length
-            ? TransactionInfo.mapFromTransactionsHistoryItems(historyItems.filter(items => items.type === 'staked'), this.maxTransactionCount, this.addressBookService)
-            : TransactionInfo.mapFromTransactionsHistoryItems(historyItems, this.maxTransactionCount, this.addressBookService)
-          : [];
-
-      })), tap(items => {
-        const history = items;
-        this.last = history && history.length > 0 ? history[history.length - 1] : {} as TransactionInfo;
-      }));
+      .pipe(
+        map((items) => {
+          return this.stakingOnly ? items.filter(i => i.transactionType === 'staked') : items;
+        }),
+        tap(items => {
+          const history = items;
+          this.last = history && history.length > 0 ? history[history.length - 1] : {} as TransactionInfo;
+        }));
   }
 
   public onScroll(): void {


### PR DESCRIPTION
This PR moves the Transaction Mapping to the Wallet Service to Improve performance on larger wallets so we don't map the same transaction items twice. 