### PR TITLE
Set block confirmation on history refresh

### DIFF
--- a/StratisCore.UI/src/app/shared/services/wallet.service.ts
+++ b/StratisCore.UI/src/app/shared/services/wallet.service.ts
@@ -254,6 +254,10 @@ export class WalletService extends RestApi {
       if (index === -1) {
         const mapped = TransactionInfo.mapFromTransactionsHistoryItem(item, this.addressBookService);
         newItems.push(mapped);
+      } else {
+        if (item.confirmedInBlock && !existingItems[index].transactionConfirmedInBlock) {
+          existingItems[index].transactionConfirmedInBlock = item.confirmedInBlock;
+        }
       }
     });
     const set = existingItems.concat(newItems);
@@ -262,8 +266,8 @@ export class WalletService extends RestApi {
 
   public broadcastTransaction(transactionHex: string): Observable<string> {
     return this.post('wallet/send-transaction', new TransactionSending(transactionHex)).pipe(
-        catchError(err => this.handleHttpError(err))
-      );
+      catchError(err => this.handleHttpError(err))
+    );
   }
 
   public sendTransaction(transaction: Transaction): Promise<TransactionResponse> {

--- a/StratisCore.UI/src/app/shared/services/wallet.service.ts
+++ b/StratisCore.UI/src/app/shared/services/wallet.service.ts
@@ -256,7 +256,9 @@ export class WalletService extends RestApi {
         newItems.push(mapped);
       } else {
         if (item.confirmedInBlock && !existingItems[index].transactionConfirmedInBlock) {
-          existingItems[index].transactionConfirmedInBlock = item.confirmedInBlock;
+          existingItems.filter(existing => existing.id === item.id).forEach(existing => {
+            existing.transactionConfirmedInBlock = item.confirmedInBlock;
+          });
         }
       }
     });


### PR DESCRIPTION
This PR fixes setting of block confirmations for Transaction Items after history refresh 